### PR TITLE
chore(rust): My previous build failed due to some compiler errors

### DIFF
--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -1,7 +1,7 @@
 export RUSTUP_HOME=/usr/local/rustup
 export CARGO_HOME=/usr/local/cargo
 export PATH=/usr/local/cargo/bin:$PATH
-export RUST_VERSION=1.46.0
+export RUST_VERSION=1.60.0
 
 set -eux
 dpkgArch="$(dpkg --print-architecture)"


### PR DESCRIPTION
Upgrading Rust seems to fix this issue


```bash


error[E0658]: const generics are unstable
    = note: see issue #44580 https://github.com/rust-lang/rust/issues/44580 for more information
error: could not compile `zeroize`
```


[Previous Build](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/320464205386/projects/dino-park-whoami/build/dino-park-whoami%3Adc9dedf9-bc2b-442b-b3df-b065cec16e4f?region=us-west-2)